### PR TITLE
[BugFix] cooldownのtype指定忘れ修正

### DIFF
--- a/cogs/game_controller.py
+++ b/cogs/game_controller.py
@@ -21,7 +21,7 @@ class Game(commands.Cog):
         self.game_members: List[int] = []
 
     @commands.command()
-    @commands.cooldown(1, 30)
+    @commands.cooldown(1, 30, commands.BucketType.user)
     async def apply(self, ctx: commands.Context, target_member: discord.Member) -> None:
         if ctx.author.id == target_member.id:
             await ctx.send('あなた自身を選ぶことはできません。')


### PR DESCRIPTION
`command.cooldown`のtypeを指定し忘れていたので、全ユーザー共通のcooldownがかかる仕様になっていました。
修正したのでご確認ください、申し訳ありません（；´д｀）ゞ