### PR TITLE
DBが動かない問題を解決

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   postgres:
     image: postgres
@@ -9,7 +9,7 @@ services:
     volumes:
       - pgsql-aria-data:/var/lib/postgresql/data
       - ./postgres/init:/docker-entrypoint-initdb.d
-    container_name: 'mydb'
+    container_name: "mydb"
     command: -p 5431
   main:
     environment:
@@ -19,7 +19,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/python/Dockerfile
-    container_name: 'main'
+    container_name: "main"
 
 volumes:
   pgsql-aria-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ version: "3"
 services:
   postgres:
     image: postgres
-    environment:
-      env_file: postgres.env
+    env_file: postgres.env
     ports:
       - "5431:5431"
     volumes:


### PR DESCRIPTION
- 書式が揃っていなかったので揃えました。
- env ファイルが読み込まれていなかったので、修正しました。(Thanks to aiotter)

env ファイルを読み込むようになったことで、バージョン指定が必須なバグは発生しなくなりました。

close #76 